### PR TITLE
FEAT(dev): dev with gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,14 @@
+FROM gitpod/workspace-full
+
+USER root
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN apt-get update \
+#    && apt-get install -y bastet \
+#    && apt-get clean && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
+#
+# More information: https://www.gitpod.io/docs/42_config_docker/
+
+RUN yarn global add @vue/cli

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+image:
+  file: .gitpod.Dockerfile
+
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/43_config_ports/
+ports:
+  - port: 3000
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/44_config_start_tasks/
+tasks:
+  - init: echo 'init script' # runs during prebuild
+    command: echo 'start script'


### PR DESCRIPTION
Now when you init a new workspace in gitpod, command `vue` will be installed automatically through `yarn global add @vue/cli`.

The reason why not running `yarn global add` at [init command](https://www.gitpod.io/docs/44_config_start_tasks/#code-classlanguage-textinitcode-command) is that `vue` command won't be accesible in bash if it's installed this way.
